### PR TITLE
refactor specs

### DIFF
--- a/spec/soft_delete/restorable_spec.rb
+++ b/spec/soft_delete/restorable_spec.rb
@@ -18,13 +18,12 @@ RSpec.describe SoftDelete::Restorable do
     end
   end
 
-  describe ".deleted" do
-    context "when there is more than one default scope" do
-
+  describe '.deleted' do
+    context 'when there is more than one default scope' do
       let!(:without_title) { Note.create(body: 'blah blah', deleted_at: Time.now) }
       let!(:with_title) { Note.create(body: 'blah blah', title: 'some title', deleted_at: Time.now) }
 
-      it "only removes the default scope associated with deleted_at" do
+      it 'only removes the default scope associated with deleted_at' do
         expect(Note.deleted.count).to eq(1)
         expect(Note.deleted.first).to eq(with_title)
       end
@@ -34,20 +33,20 @@ RSpec.describe SoftDelete::Restorable do
   describe '#restore_soft_delete' do
     subject { note.restore_soft_delete(validate: validate) }
 
-    let(:note) { Note.create(body: 'blah blah', title: "some note", deleted_at: Time.now) }
+    let(:note) { Note.create(body: 'blah blah', title: 'some note', deleted_at: Time.now) }
     let(:validate) { true }
 
-    it "restores the record" do
-      expect { subject }.to change{ Note.count }.by(1)
+    it 'restores the record' do
+      expect { subject }.to change { Note.count }.by(1)
     end
 
-    context "when skipping validations" do
-      let(:note) { Note.create(title: "some note", deleted_at: Time.now) }
+    context 'when skipping validations' do
+      let(:note) { Note.create(title: 'some note', deleted_at: Time.now) }
       let(:validate) { false }
 
-      it "restores an otherwise invalid record" do
+      it 'restores an otherwise invalid record' do
         expect(note.valid?).to eq(false)
-        expect { subject }.to change{ Note.count }.by(1)
+        expect { subject }.to change { Note.count }.by(1)
       end
     end
   end

--- a/spec/soft_delete/soft_deletable_soft_delete_spec.rb
+++ b/spec/soft_delete/soft_deletable_soft_delete_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+RSpec.describe SoftDelete::SoftDeletable do
+  describe '#soft_delete' do
+    with_model :Note, scope: :all do
+      table do |t|
+        t.string :title
+        t.datetime :deleted_at
+        t.integer :author_id
+      end
+
+      model do
+        include SoftDelete::SoftDeletable
+        belongs_to :author
+      end
+    end
+
+    let!(:note1) { Note.create!(title: 'note 1') }
+    let!(:note2) { Note.create!(title: 'note 2') }
+
+    it 'hides the record' do
+      expect do
+        puts "before: #{Note.pluck(:deleted_at)}"
+        note2.soft_delete
+        puts "after: #{Note.pluck(:deleted_at)}"
+      end.to change { Note.count }.from(2).to(1)
+    end
+
+    describe 'dependency behavior' do
+      subject { author.soft_delete }
+      context 'when dependent default' do
+        context 'when the relation is dependent destroy' do
+          with_model :Author, scope: :all do
+            table do |t|
+              t.string :name
+              t.datetime :deleted_at
+            end
+
+            model do
+              include SoftDelete::SoftDeletable.dependent(:default)
+              has_many :notes, dependent: :destroy
+            end
+          end
+          let(:author) { Author.create!(name: 'Stephen') }
+          let!(:note1) { Note.create!(title: 'note 1', author: author) }
+          let!(:note2) { Note.create!(title: 'note 2', author: author) }
+
+          it 'destroys the related records' do
+            expect { subject }.to change { Note.unscoped.count }.from(2).to(0)
+          end
+        end
+        context 'when the relation is dependent delete_all' do
+          with_model :Author, scope: :all do
+            table do |t|
+              t.string :name
+              t.datetime :deleted_at
+            end
+
+            model do
+              include SoftDelete::SoftDeletable.dependent(:default)
+              has_many :notes, dependent: :delete_all
+            end
+          end
+          let(:author) { Author.create!(name: 'Stephen') }
+          let!(:note1) { Note.create!(title: 'note 1', author: author) }
+          let!(:note2) { Note.create!(title: 'note 2', author: author) }
+
+          it 'deletes the related records' do
+            expect { subject }.to change { Note.unscoped.count }.from(2).to(0)
+          end
+        end
+        context 'when the relation is dependent nullify' do
+          with_model :Author, scope: :all do
+            table do |t|
+              t.string :name
+              t.datetime :deleted_at
+            end
+
+            model do
+              include SoftDelete::SoftDeletable.dependent(:default)
+              has_many :notes, dependent: :nullify
+            end
+          end
+          let(:author) { Author.create!(name: 'Stephen') }
+          let!(:note1) { Note.create!(title: 'note 1', author: author) }
+          let!(:note2) { Note.create!(title: 'note 2', author: author) }
+
+          it 'nullifies the related records' do
+            expect { subject }.to change { Note.where(author_id: nil).count }.from(0).to(2)
+          end
+        end
+        context 'when the relation is dependent restrict_with_exception' do
+          with_model :Author, scope: :all do
+            table do |t|
+              t.string :name
+              t.datetime :deleted_at
+            end
+
+            model do
+              include SoftDelete::SoftDeletable.dependent(:default)
+              has_many :notes, dependent: :restrict_with_exception
+            end
+          end
+          let(:author) { Author.create!(name: 'Stephen') }
+          let!(:note1) { Note.create!(title: 'note 1', author: author) }
+          let!(:note2) { Note.create!(title: 'note 2', author: author) }
+
+          it 'raises ActiveRecord::DeleteRestrictionError' do
+            expect { subject }.to raise_error(ActiveRecord::DeleteRestrictionError)
+          end
+        end
+        context 'when the relation is dependent restrict_with_error'
+      end
+      context 'when dependent soft_delete' do
+        context 'when the relation is dependent destroy' do
+          with_model :Author, scope: :all do
+            table do |t|
+              t.string :name
+              t.datetime :deleted_at
+            end
+
+            model do
+              include SoftDelete::SoftDeletable.dependent(:soft_delete)
+              has_many :notes, dependent: :destroy
+              before_destroy :before
+              around_destroy :around
+              after_destroy :after
+
+              def before; end
+
+              def around; end
+
+              def after; end
+            end
+          end
+          let(:author) { Author.create!(name: 'Stephen') }
+          let!(:note1) { Note.create!(title: 'note 1', author: author) }
+          let!(:note2) { Note.create!(title: 'note 2', author: author) }
+
+          it 'soft deletes the related records' do
+            expect do
+              subject
+            end.to change { Note.count }.from(2).to(0)
+                                        .and change { Note.unscoped.count }.by(0)
+          end
+
+          describe 'callbacks' do
+            it 'runs the callbacks in order' do
+              expect(author).to receive(:before).ordered
+              expect(author).to receive(:around).ordered
+              expect(author).to receive(:after).ordered
+              subject
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/soft_delete/soft_deletable_spec.rb
+++ b/spec/soft_delete/soft_deletable_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe SoftDelete::SoftDeletable do
-  describe ".dependent" do
+  describe '.dependent' do
     subject { described_class.dependent(behavior) }
 
     let(:behavior) { :ignore }
@@ -18,8 +18,8 @@ RSpec.describe SoftDelete::SoftDeletable do
     end
   end
 
-  describe ".not_scoped" do
-    with_model :Note, scope: :all do
+  describe '.not_scoped' do
+    with_model :NoteNotScoped, scope: :all do
       table do |t|
         t.string :title
         t.datetime :deleted_at
@@ -31,174 +31,20 @@ RSpec.describe SoftDelete::SoftDeletable do
         belongs_to :author
       end
     end
-    let!(:note) { Note.create!(title: 'note 1') }
+    let!(:note_not_scoped) { NoteNotScoped.create!(title: 'note 1') }
 
-    it "does not include a default scope" do
-      expect { note.soft_delete }.not_to change { Note.count }.from(1)
+    it 'does not include a default scope' do
+      expect { note_not_scoped.soft_delete }.not_to change { NoteNotScoped.count }.from(1)
     end
 
-    it "includes an active scope" do
-      expect(Note.active.first).to eq(note)
-      note.soft_delete!
-      expect(Note.active).to be_empty
+    it 'includes an active scope' do
+      expect(NoteNotScoped.active.first).to eq(note_not_scoped)
+      note_not_scoped.soft_delete!
+      expect(NoteNotScoped.active).to be_empty
     end
 
     it 'returns self' do
       expect(described_class.not_scoped).to eq(described_class)
-    end
-  end
-
-  describe '#soft_delete' do
-    subject { note2.soft_delete }
-
-    with_model :Note, scope: :all do
-      table do |t|
-        t.string :title
-        t.datetime :deleted_at
-        t.integer :author_id
-      end
-
-      model do
-        include SoftDelete::SoftDeletable
-        belongs_to :author
-      end
-    end
-
-    let!(:note1) { Note.create!(title: 'note 1') }
-    let!(:note2) { Note.create!(title: 'note 2') }
-
-    it 'hides the record' do
-      expect { subject }.to change { Note.count }.from(2).to(1)
-    end
-
-    describe 'dependency behavior' do
-      subject { author.soft_delete }
-      context 'when dependent default' do
-        context 'when the relation is dependent destroy' do
-          with_model :Author, scope: :all do
-            table do |t|
-              t.string :name
-              t.datetime :deleted_at
-            end
-
-            model do
-              include SoftDelete::SoftDeletable.dependent(:default)
-              has_many :notes, dependent: :destroy
-            end
-          end
-          let(:author) { Author.create!(name: 'Stephen') }
-          let!(:note1) { Note.create!(title: 'note 1', author: author) }
-          let!(:note2) { Note.create!(title: 'note 2', author: author) }
-
-          it 'destroys the related records' do
-            expect { subject }.to change { Note.unscoped.count }.from(2).to(0)
-          end
-        end
-        context 'when the relation is dependent delete_all' do
-          with_model :Author, scope: :all do
-            table do |t|
-              t.string :name
-              t.datetime :deleted_at
-            end
-
-            model do
-              include SoftDelete::SoftDeletable.dependent(:default)
-              has_many :notes, dependent: :delete_all
-            end
-          end
-          let(:author) { Author.create!(name: 'Stephen') }
-          let!(:note1) { Note.create!(title: 'note 1', author: author) }
-          let!(:note2) { Note.create!(title: 'note 2', author: author) }
-
-          it 'deletes the related records' do
-            expect { subject }.to change { Note.unscoped.count }.from(2).to(0)
-          end
-        end
-        context 'when the relation is dependent nullify' do
-          with_model :Author, scope: :all do
-            table do |t|
-              t.string :name
-              t.datetime :deleted_at
-            end
-
-            model do
-              include SoftDelete::SoftDeletable.dependent(:default)
-              has_many :notes, dependent: :nullify
-            end
-          end
-          let(:author) { Author.create!(name: 'Stephen') }
-          let!(:note1) { Note.create!(title: 'note 1', author: author) }
-          let!(:note2) { Note.create!(title: 'note 2', author: author) }
-
-          it 'nullifies the related records' do
-            expect { subject }.to change { Note.where(author_id: nil).count }.from(0).to(2)
-          end
-        end
-        context 'when the relation is dependent restrict_with_exception' do
-          with_model :Author, scope: :all do
-            table do |t|
-              t.string :name
-              t.datetime :deleted_at
-            end
-
-            model do
-              include SoftDelete::SoftDeletable.dependent(:default)
-              has_many :notes, dependent: :restrict_with_exception
-            end
-          end
-          let(:author) { Author.create!(name: 'Stephen') }
-          let!(:note1) { Note.create!(title: 'note 1', author: author) }
-          let!(:note2) { Note.create!(title: 'note 2', author: author) }
-
-          it 'raises ActiveRecord::DeleteRestrictionError' do
-            expect { subject }.to raise_error(ActiveRecord::DeleteRestrictionError)
-          end
-        end
-        context 'when the relation is dependent restrict_with_error'
-      end
-      context 'when dependent soft_delete' do
-        context 'when the relation is dependent destroy' do
-          with_model :Author, scope: :all do
-            table do |t|
-              t.string :name
-              t.datetime :deleted_at
-            end
-
-            model do
-              include SoftDelete::SoftDeletable.dependent(:soft_delete)
-              has_many :notes, dependent: :destroy
-              before_destroy :before
-              around_destroy :around
-              after_destroy :after
-
-              def before; end
-
-              def around; end
-
-              def after; end
-            end
-          end
-          let(:author) { Author.create!(name: 'Stephen') }
-          let!(:note1) { Note.create!(title: 'note 1', author: author) }
-          let!(:note2) { Note.create!(title: 'note 2', author: author) }
-
-          it 'soft deletes the related records' do
-            expect {
-              subject
-            }.to change { Note.count }.from(2).to(0)
-             .and change { Note.unscoped.count }.by(0)
-          end
-
-          describe 'callbacks' do
-            it 'runs the callbacks in order' do
-              expect(author).to receive(:before).ordered
-              expect(author).to receive(:around).ordered
-              expect(author).to receive(:after).ordered
-              subject
-            end
-          end
-        end
-      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "bundler/setup"
-require "soft_delete"
+require 'bundler/setup'
+require 'soft_delete'
 
 require 'database_cleaner'
 require 'with_model'
@@ -22,7 +22,7 @@ RSpec.configure do |config|
   config.extend WithModel
 
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
there is a condition where the specs are flaky because the with_model has had the .not_scoped set and for some reason it is sticky-- even with another model defined.  Rather than wrestle with it, easier to just break the tests out...